### PR TITLE
feat(post,user): 엔티티 연관관계 설정

### DIFF
--- a/src/main/java/com/gujo/uminity/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/gujo/uminity/post/dto/request/PostCreateRequest.java
@@ -1,12 +1,16 @@
 package com.gujo.uminity.post.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 public class PostCreateRequest {
+    @NotNull
+    private String userId;
+
     @NotBlank(message = "제목을 반드시 입력하세요")
     private String title;
 
@@ -20,11 +24,12 @@ public class PostCreateRequest {
 Dto 에는 전달 객체여서 괜찮은데 Entity 에는 @Data 자제
 객체 스스로의 책임과 통제가 약화된다
 모든 필드에 퍼블릭한 접근 만들고 캡슐화와 무결성 해칠 수 있다.
- */
 
-/*
 서버에서 생성되는 필드 postId랑 createdAt은 클라이언트가 보내지말고 서버에서 채워서 응답 DTO에 넣자
 책임과 관심사의 분리
 게시글 생성/ 수정 입력
+
+
+userId를 추가해야 누가쓴 글인지 알 수 있다.
  */
 

--- a/src/main/java/com/gujo/uminity/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/gujo/uminity/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.gujo.uminity.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PostUpdateRequest {
+    @NotBlank(message = "제목을 반드시 입력하세요")
+    private String title;
+
+    @NotBlank(message = "내용도 입력하세요")
+    private String content;
+}
+
+/*
+생각 정리
+
+update 시 create와 동일하게 동작하는데 그냥 의도를 분명히 하기 위해 따로 요청 DTO 분리
+
+ */
+

--- a/src/main/java/com/gujo/uminity/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/gujo/uminity/post/dto/response/PostResponseDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 public class PostResponseDto {
     private Long postId;
+    private String authorName;
     private String title;
     private String content;
     private LocalDateTime createdAt;
@@ -19,6 +20,7 @@ public class PostResponseDto {
     public static PostResponseDto fromEntity(Post p) {
         return PostResponseDto.builder()
                 .postId(p.getPostId())
+                .authorName(p.getUser().getName())
                 .title(p.getTitle())
                 .content(p.getContent())
                 .createdAt(p.getCreatedAt())
@@ -28,7 +30,7 @@ public class PostResponseDto {
 }
 
 /*
-서버 생성값 Id, 시간, 조회수
-클라이언트 입력 값 제목, 내용
+서버 생성값 postId, 시간, 조회수
+클라이언트 입력 값 제목, 내용 + user 엔티티의 아이디
 컨트롤러가 해당 DTO를 JSON 으로 응답
  */

--- a/src/main/java/com/gujo/uminity/post/entity/Post.java
+++ b/src/main/java/com/gujo/uminity/post/entity/Post.java
@@ -1,17 +1,10 @@
 package com.gujo.uminity.post.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.gujo.uminity.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "posts")
@@ -19,14 +12,16 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long postId;
 
-    @Column(name = "user_id", nullable = false)
-    private UUID userId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Column(nullable = false)
     private String title;
@@ -40,3 +35,10 @@ public class Post {
     @Column(name = "view_cnt")
     private Integer viewCnt;
 }
+
+
+/*
+연관관계를 위해서 UUID 필드 삭제하고 User와 다대일 관계 설정
+fetch LAZY 실제로 사용할 때만 유저조회
+
+ */

--- a/src/main/java/com/gujo/uminity/post/service/PostService.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostService.java
@@ -1,11 +1,21 @@
 package com.gujo.uminity.post.service;
 
 import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
+import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 
 public interface PostService {
     PageResponse<PostResponseDto> listPosts(PostListRequest req);
+
+    PostResponseDto getPost(Long postId);
+
+    PostResponseDto createPost(PostCreateRequest request);
+
+    PostResponseDto updatePost(Long postId, PostUpdateRequest request);
+
+    void deletePost(Long postId);
 }
 
 /*

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -7,6 +7,8 @@ import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
+import com.gujo.uminity.user.entity.User;
+import com.gujo.uminity.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,7 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import static java.time.LocalDateTime.now;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +25,7 @@ import java.time.LocalDateTime;
 public class PostServiceImpl implements PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
     @Override
     public PageResponse<PostResponseDto> listPosts(PostListRequest req) {
@@ -71,11 +74,24 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public PostResponseDto createPost(PostCreateRequest request) {
-        Post post = new Post();
-        post.setTitle(request.getTitle());
-        post.setContent(request.getContent());
-        post.setCreatedAt(LocalDateTime.now());
-        post.setViewCnt(0);
+
+        // 유저 조회부터 해야됨
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
+
+//        Post post = new Post();
+//        post.setTitle(request.getTitle());
+//        post.setContent(request.getContent());
+//        post.setCreatedAt(LocalDateTime.now());
+//        post.setViewCnt(0);
+
+        Post post = Post.builder()
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .createdAt(now())
+                .viewCnt(0)
+                .build();
 
         Post saved = postRepository.save(post);
         return PostResponseDto.fromEntity(saved);
@@ -102,4 +118,6 @@ CRUD 만들고 났고 조회랑 수정은 있는지 여부를 확인해야되고
 그리고 응답객체에 post 빌더패턴으로 생성해서 넣어주기
 
 JPA 작업을 하나의 트랜잭션으로 묶고 자동으로 롤백해서
+
+연관관계로 UserRepository 추가해서 반영
  */

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -1,7 +1,9 @@
 package com.gujo.uminity.post.service;
 
 import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
+import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
@@ -11,9 +13,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostServiceImpl implements PostService {
 
     private final PostRepository postRepository;
@@ -52,5 +58,48 @@ public class PostServiceImpl implements PostService {
                 dtoPage.getTotalElements(),
                 dtoPage.getTotalPages()
         );
+        // Page -> 매핑 -> 페이지리스폰스로 응답
+    }
+
+    @Override
+    @Transactional
+    public PostResponseDto getPost(Long postId) {
+        Post post = postRepository.findById(postId).
+                orElseThrow(() -> new IllegalArgumentException("존재 하지 않습니다"));
+        return PostResponseDto.fromEntity(post);
+    }
+
+    @Override
+    public PostResponseDto createPost(PostCreateRequest request) {
+        Post post = new Post();
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+        post.setCreatedAt(LocalDateTime.now());
+        post.setViewCnt(0);
+
+        Post saved = postRepository.save(post);
+        return PostResponseDto.fromEntity(saved);
+    }
+
+    @Override
+    public PostResponseDto updatePost(Long postId, PostUpdateRequest request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재 하지 압ㅎ습니다"));
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+
+        return PostResponseDto.fromEntity(post);
+    }
+
+    @Override
+    public void deletePost(Long postId) {
+        postRepository.deleteById(postId);
     }
 }
+
+/*
+CRUD 만들고 났고 조회랑 수정은 있는지 여부를 확인해야되고 없으면 예외 던지기
+그리고 응답객체에 post 빌더패턴으로 생성해서 넣어주기
+
+JPA 작업을 하나의 트랜잭션으로 묶고 자동으로 롤백해서
+ */

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -65,7 +65,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public PostResponseDto getPost(Long postId) {
         Post post = postRepository.findById(postId).
-                orElseThrow(() -> new IllegalArgumentException("존재 하지 않습니다"));
+                orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         return PostResponseDto.fromEntity(post);
     }
 

--- a/src/main/java/com/gujo/uminity/user/entity/User.java
+++ b/src/main/java/com/gujo/uminity/user/entity/User.java
@@ -1,22 +1,10 @@
 package com.gujo.uminity.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 @Entity
 @Table(name = "users")
@@ -24,6 +12,7 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class User {
 
     @Id

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,20 +1,16 @@
 spring.application.name=Uminity
-
 #data source
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/uminity
+spring.datasource.url=jdbc:mysql://124.49.160.43:3306/uminity
 spring.datasource.username=${MYSQL_USERNAME}
 spring.datasource.password=${MYSQL_PASSWORD}
-
 # session persistence
 server.servlet.session.persistent=false
 logging.level.org.springframework.security=debug
-
 #jpa
 #spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
-
 #logging
 logging.level.root=info
 logging.level.com.mycom.myapp=debug

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=Uminity
 #data source
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://124.49.160.43:3306/uminity
+spring.datasource.url=${MYSQL_URL}
 spring.datasource.username=${MYSQL_USERNAME}
 spring.datasource.password=${MYSQL_PASSWORD}
 # session persistence

--- a/src/test/java/com/gujo/uminity/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/gujo/uminity/post/repository/PostRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.gujo.uminity.post.repository;
 
 import com.gujo.uminity.post.entity.Post;
+import com.gujo.uminity.user.entity.User;
+import com.gujo.uminity.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
-import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,20 +23,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PostRepositoryTest {
     @Autowired
     private PostRepository postRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private User userTest;
 
     @BeforeEach
     void setUp() {
+        userTest = userRepository.save(User.builder()
+                .name("테스트")
+                .email("test@test.com")
+                .password("password")
+                .phone("010-111-1111")
+                .build()
+        );
         postRepository.saveAll(List.of(
-                new Post(null, UUID.randomUUID(), "제목1", "내용1", now(), 0),
-                new Post(null, UUID.randomUUID(), "제목2", "내용2", now(), 0),
-                new Post(null, UUID.randomUUID(), "제목3", "내용3", now(), 0)
+                new Post(null, userTest, "제목1", "내용1", now(), 0),
+                new Post(null, userTest, "제목2", "내용2", now(), 0),
+                new Post(null, userTest, "제목3", "내용3", now(), 0)
         ));
     }
 
     @Test
     @DisplayName("저장하고 조회까지")
     void 저장조회() {
-        Post p = new Post(null, UUID.randomUUID(), "테스트제목", "테스트 내용", now(), 0);
+        Post p = new Post(null, userTest, "테스트제목", "테스트 내용", now(), 0);
         Post saved = postRepository.save(p);
 
         Post found = postRepository.findById(saved.getPostId())

--- a/src/test/java/com/gujo/uminity/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/gujo/uminity/post/repository/PostRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.gujo.uminity.post.repository;
 
 import com.gujo.uminity.post.entity.Post;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import java.util.List;
 import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
@@ -21,12 +23,18 @@ class PostRepositoryTest {
     @Autowired
     private PostRepository postRepository;
 
+    @BeforeEach
+    void setUp() {
+        postRepository.saveAll(List.of(
+                new Post(null, UUID.randomUUID(), "제목1", "내용1", now(), 0),
+                new Post(null, UUID.randomUUID(), "제목2", "내용2", now(), 0),
+                new Post(null, UUID.randomUUID(), "제목3", "내용3", now(), 0)
+        ));
+    }
+
     @Test
     @DisplayName("제목 포함 검색, 페이징이 정상")
     void 제목() {
-        postRepository.save(new Post(null, UUID.randomUUID(), "제목1", "내용1", now(), 0));
-        postRepository.save(new Post(null, UUID.randomUUID(), "제목2", "내용2", now(), 0));
-        postRepository.save(new Post(null, UUID.randomUUID(), "제목3", "내용3", now(), 0));
 
         Pageable pageable = PageRequest.of(0, 2, Sort.by("createdAt").descending());
 
@@ -37,6 +45,20 @@ class PostRepositoryTest {
         assertThat(page.getTotalPages()).isEqualTo(2);
 
         assertThat(page.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("제목 내용 포함 검색, 페이징이 정상")
+    void 제목내용() {
+
+        Pageable pageable = PageRequest.of(0, 3, Sort.by("createdAt").descending());
+
+        Page<Post> page = postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase("제목", "내용", pageable);
+
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getTotalPages()).isEqualTo(1);
+
+        assertThat(page.getContent()).hasSize(3);
     }
 }
 

--- a/src/test/java/com/gujo/uminity/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/gujo/uminity/post/repository/PostRepositoryTest.java
@@ -33,6 +33,18 @@ class PostRepositoryTest {
     }
 
     @Test
+    @DisplayName("저장하고 조회까지")
+    void 저장조회() {
+        Post p = new Post(null, UUID.randomUUID(), "테스트제목", "테스트 내용", now(), 0);
+        Post saved = postRepository.save(p);
+
+        Post found = postRepository.findById(saved.getPostId())
+                .orElseThrow(() -> new AssertionError("조회안됨"));
+        assertThat(found.getTitle()).isEqualTo("테스트제목");
+        assertThat(found.getContent()).isEqualTo("테스트 내용");
+    }
+
+    @Test
     @DisplayName("제목 포함 검색, 페이징이 정상")
     void 제목() {
 

--- a/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.gujo.uminity.post.service;
 
 import com.gujo.uminity.post.dto.request.PostCreateRequest;
+import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
@@ -16,7 +17,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
@@ -88,4 +90,36 @@ class PostServiceImplTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 게시글");
     }
+
+    @Test
+    @DisplayName("updatePost: 존재하는 ID면 title/content 변경 후 DTO 반환")
+    void updatePost_success() {
+        // given: 수정 대상 엔티티 조회
+        given(postRepository.findById(1L))
+                .willReturn(Optional.of(postTest));
+
+        PostUpdateRequest req = new PostUpdateRequest();
+        req.setTitle("수정된제목");
+        req.setContent("수정된내용");
+
+        // when
+        PostResponseDto dto = postService.updatePost(1L, req);
+
+        // then 엔티티가 변경되어 DTO에 반영되었는지
+        assertThat(dto.getTitle()).isEqualTo("수정된제목");
+        assertThat(dto.getContent()).isEqualTo("수정된내용");
+    }
+
+    @Test
+    @DisplayName("updatePost: 없는 ID면 IllegalArgumentException 발생")
+    void updatePost_notFound() {
+        // given findById → 빈 Optional
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        // When / Then
+        assertThatThrownBy(() -> postService.updatePost(123L, new PostUpdateRequest()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
 }

--- a/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
@@ -12,10 +12,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
@@ -40,7 +42,7 @@ class PostServiceImplTest {
     }
 
     @Test
-    @DisplayName("create 저장된 엔티티를 DTO로 반환")
+    @DisplayName("createPost: 저장된 엔티티를 DTO로 반환")
     void createPost_success() {
         // given
         PostCreateRequest req = new PostCreateRequest();
@@ -58,4 +60,32 @@ class PostServiceImplTest {
     /*
     서비스 -> 레포지토리 -> DTO 매핑 순서
      */
+
+    @Test
+    @DisplayName("getPost: 존재하는 ID면 DTO 반환")
+    void getPost_success() {
+        // given: findById(1L) 이 postTest 를 반환
+        given(postRepository.findById(1L))
+                .willReturn(Optional.of(postTest));
+
+        // when: 서비스 호출
+        PostResponseDto dto = postService.getPost(1L);
+
+        // then: DTO 필드가 postTest 와 일치
+        assertThat(dto.getPostId()).isEqualTo(postTest.getPostId());
+        assertThat(dto.getTitle()).isEqualTo(postTest.getTitle());
+    }
+
+    @Test
+    @DisplayName("getPost: 없는 ID면 IllegalArgumentException 발생")
+    void getPost_notFound() {
+        // given: findById(any) 이 빈 Optional
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        // When / Then: 예외 던짐
+        assertThatThrownBy(() -> postService.getPost(999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 게시글");
+    }
 }


### PR DESCRIPTION
- Post 엔티티에서 userId 필드 제거하고
  @ManyToOne(fetch = FetchType.LAZY, optional = false)
  @JoinColumn(name = "user_id") private User user 매핑 추가

- User 엔티티의 userId를
  @GeneratedValue(strategy = GenerationType.UUID) String 타입으로 자동 생성하도록 변경