### PR TITLE
feat: 쿠키 기반 조회수 중복 방지 로직 추가

### DIFF
--- a/src/main/java/com/gujo/uminity/advice/AuthExceptionAdvice.java
+++ b/src/main/java/com/gujo/uminity/advice/AuthExceptionAdvice.java
@@ -1,10 +1,12 @@
 package com.gujo.uminity.advice;
 
 import com.gujo.uminity.auth.controller.AuthController;
-import com.gujo.uminity.common.ErrorResponse;
-import com.gujo.uminity.common.ResultStatus;
+import com.gujo.uminity.common.response.ErrorResponse;
+import com.gujo.uminity.common.response.ResultStatus;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/gujo/uminity/auth/dto/RegisterResponseDto.java
+++ b/src/main/java/com/gujo/uminity/auth/dto/RegisterResponseDto.java
@@ -1,6 +1,6 @@
 package com.gujo.uminity.auth.dto;
 
-import com.gujo.uminity.common.ResultStatus;
+import com.gujo.uminity.common.response.ResultStatus;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/gujo/uminity/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/auth/service/AuthServiceImpl.java
@@ -2,7 +2,7 @@ package com.gujo.uminity.auth.service;
 
 import com.gujo.uminity.auth.dto.RegisterRequestDto;
 import com.gujo.uminity.auth.dto.RegisterResponseDto;
-import com.gujo.uminity.common.ResultStatus;
+import com.gujo.uminity.common.response.ResultStatus;
 import com.gujo.uminity.user.entity.Role;
 import com.gujo.uminity.user.entity.User;
 import com.gujo.uminity.user.repository.RoleRepository;

--- a/src/main/java/com/gujo/uminity/comment/controller/CommentController.java
+++ b/src/main/java/com/gujo/uminity/comment/controller/CommentController.java
@@ -5,7 +5,7 @@ import com.gujo.uminity.comment.dto.request.CommentListRequest;
 import com.gujo.uminity.comment.dto.request.CommentUpdateRequest;
 import com.gujo.uminity.comment.dto.response.CommentResponseDto;
 import com.gujo.uminity.comment.service.CommentService;
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.common.security.MyUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/gujo/uminity/comment/service/CommentService.java
+++ b/src/main/java/com/gujo/uminity/comment/service/CommentService.java
@@ -4,7 +4,7 @@ import com.gujo.uminity.comment.dto.request.CommentCreateRequest;
 import com.gujo.uminity.comment.dto.request.CommentListRequest;
 import com.gujo.uminity.comment.dto.request.CommentUpdateRequest;
 import com.gujo.uminity.comment.dto.response.CommentResponseDto;
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 
 public interface CommentService {
     PageResponse<CommentResponseDto> listComments(Long postId, CommentListRequest req);

--- a/src/main/java/com/gujo/uminity/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/comment/service/CommentServiceImpl.java
@@ -7,7 +7,7 @@ import com.gujo.uminity.comment.dto.response.ChildCommentDto;
 import com.gujo.uminity.comment.dto.response.CommentResponseDto;
 import com.gujo.uminity.comment.entity.Comment;
 import com.gujo.uminity.comment.repository.CommentRepository;
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
 import com.gujo.uminity.user.entity.User;

--- a/src/main/java/com/gujo/uminity/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gujo/uminity/common/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.gujo.uminity.common.exception.handler;
 
-import com.gujo.uminity.common.ErrorResponse;
+import com.gujo.uminity.common.response.ErrorResponse;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/gujo/uminity/common/response/ErrorResponse.java
+++ b/src/main/java/com/gujo/uminity/common/response/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.gujo.uminity.common;
+package com.gujo.uminity.common.response;
 
 import lombok.Builder;
 

--- a/src/main/java/com/gujo/uminity/common/response/ResultStatus.java
+++ b/src/main/java/com/gujo/uminity/common/response/ResultStatus.java
@@ -1,4 +1,4 @@
-package com.gujo.uminity.common;
+package com.gujo.uminity.common.response;
 
 public enum ResultStatus {
     SUCCESS, FAIL

--- a/src/main/java/com/gujo/uminity/common/security/MyAuthenticationFailureHandler.java
+++ b/src/main/java/com/gujo/uminity/common/security/MyAuthenticationFailureHandler.java
@@ -1,11 +1,13 @@
 package com.gujo.uminity.common.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gujo.uminity.common.ErrorResponse;
+import com.gujo.uminity.common.response.ErrorResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;

--- a/src/main/java/com/gujo/uminity/common/web/PageController.java
+++ b/src/main/java/com/gujo/uminity/common/web/PageController.java
@@ -1,9 +1,8 @@
-package com.gujo.uminity.common;
+package com.gujo.uminity.common.web;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class PageController {
@@ -27,22 +26,22 @@ public class PageController {
     public String register() {
         return "register.html";
     }
-    
+
     @GetMapping("/postDetail/{postId}")
     public String postDetail(@PathVariable("postId") String postId) {
-    	System.out.println(postId);
+        System.out.println(postId);
         return "/postDetail.html";
     }
-    
+
     @GetMapping("/postForm")
     public String postCreateForm() {
         return "postForm.html";
     }
-    
+
     @GetMapping("/postForm/{postId}")
     public String postUpdateForm(@PathVariable("postId") String postId) {
-    	System.out.println(postId);
+        System.out.println(postId);
         return "/postForm.html";
     }
-    
+
 }

--- a/src/main/java/com/gujo/uminity/common/web/PageResponse.java
+++ b/src/main/java/com/gujo/uminity/common/web/PageResponse.java
@@ -1,4 +1,4 @@
-package com.gujo.uminity.common;
+package com.gujo.uminity.common.web;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/gujo/uminity/config/WebConfig.java
+++ b/src/main/java/com/gujo/uminity/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.gujo.uminity.config;
+
+import com.gujo.uminity.config.interceptor.ViewCountInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final ViewCountInterceptor viewCountInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(viewCountInterceptor)
+                .addPathPatterns("/api/posts/*");  // /api/posts/{postId}
+    }
+}

--- a/src/main/java/com/gujo/uminity/config/interceptor/ViewCountInterceptor.java
+++ b/src/main/java/com/gujo/uminity/config/interceptor/ViewCountInterceptor.java
@@ -1,0 +1,49 @@
+package com.gujo.uminity.config.interceptor;
+
+import com.gujo.uminity.post.service.PostService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class ViewCountInterceptor implements HandlerInterceptor {
+
+    private final PostService postService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
+
+        // URI가 /api/posts/{id} 패턴일 때만 처리
+        String uri = request.getRequestURI(); // ex) /api/posts/42
+        if (uri.matches("^/api/posts/\\d+$")) {
+            Long postId = Long.valueOf(uri.substring(uri.lastIndexOf('/') + 1));
+            String cookieName = "VIEWED_POST_" + postId;
+
+            boolean viewed = false;
+            Cookie[] cookies = request.getCookies();
+            if (cookies != null) {
+                for (Cookie c : cookies) {
+                    if (cookieName.equals(c.getName())) {
+                        viewed = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!viewed) {
+                postService.incrementViewCount(postId);
+                Cookie viewCookie = new Cookie(cookieName, "true");
+                viewCookie.setPath("/");
+                viewCookie.setMaxAge(3 * 60); // 3분
+                response.addCookie(viewCookie);
+            }
+        }
+        return true;  // 다음 인터셉터 또는 컨트롤러로 진행
+    }
+}

--- a/src/main/java/com/gujo/uminity/mypage/controller/MyPageController.java
+++ b/src/main/java/com/gujo/uminity/mypage/controller/MyPageController.java
@@ -1,6 +1,6 @@
 package com.gujo.uminity.mypage.controller;
 
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.mypage.dto.MyPageResponseDto;
 import com.gujo.uminity.mypage.dto.UpdateUserInfoRequestDto;
 import com.gujo.uminity.mypage.service.MyPageService;

--- a/src/main/java/com/gujo/uminity/post/controller/PostController.java
+++ b/src/main/java/com/gujo/uminity/post/controller/PostController.java
@@ -7,6 +7,7 @@ import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 import com.gujo.uminity.post.service.PostService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -42,7 +43,28 @@ public class PostController {
             HttpServletRequest request,
             HttpServletResponse response) {
         // 조회수 증가
-        postService.incrementViewCount(postId, request, response);
+
+        String cookieName = "VIEWED_POST_" + postId;
+        boolean isViewed = false;
+
+        // 요청에서 쿠키 조회
+        if (request.getCookies() != null) {
+            for (Cookie c : request.getCookies()) {
+                if (cookieName.equals(c.getName())) {
+                    isViewed = true;
+                    break;
+                }
+            }
+        }
+        // 아직 안본 게시글
+
+        if (!isViewed) {
+            postService.incrementViewCount(postId);
+            Cookie viewCookie = new Cookie(cookieName, "true");
+            viewCookie.setPath("/");
+            viewCookie.setMaxAge(60 * 3); // 일단 3분
+            response.addCookie(viewCookie);
+        }
 
         PostResponseDto dto = postService.getPost(postId);
         return ResponseEntity.ok(dto);

--- a/src/main/java/com/gujo/uminity/post/controller/PostController.java
+++ b/src/main/java/com/gujo/uminity/post/controller/PostController.java
@@ -1,15 +1,12 @@
 package com.gujo.uminity.post.controller;
 
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.common.security.MyUserDetails;
 import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 import com.gujo.uminity.post.service.PostService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,36 +36,11 @@ public class PostController {
     // 2. 단건
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> getPost(
-            @PathVariable("postId") Long postId,
-            HttpServletRequest request,
-            HttpServletResponse response) {
-        // 조회수 증가
-
-        String cookieName = "VIEWED_POST_" + postId;
-        boolean isViewed = false;
-
-        // 요청에서 쿠키 조회
-        if (request.getCookies() != null) {
-            for (Cookie c : request.getCookies()) {
-                if (cookieName.equals(c.getName())) {
-                    isViewed = true;
-                    break;
-                }
-            }
-        }
-        // 아직 안본 게시글
-
-        if (!isViewed) {
-            postService.incrementViewCount(postId);
-            Cookie viewCookie = new Cookie(cookieName, "true");
-            viewCookie.setPath("/");
-            viewCookie.setMaxAge(60 * 3); // 일단 3분
-            response.addCookie(viewCookie);
-        }
-
+            @PathVariable("postId") Long postId) {
         PostResponseDto dto = postService.getPost(postId);
         return ResponseEntity.ok(dto);
     }
+    // post 조회만 하는 컨트롤러, 조회수 관리만 하는 서비스, 쿠키를 통해 검증여부는 인터셉터가
 
     // 3. 게시글 생성
     @PostMapping

--- a/src/main/java/com/gujo/uminity/post/controller/PostController.java
+++ b/src/main/java/com/gujo/uminity/post/controller/PostController.java
@@ -7,6 +7,8 @@ import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
 import com.gujo.uminity.post.service.PostService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +38,12 @@ public class PostController {
     // 2. 단건
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> getPost(
-            @PathVariable("postId") Long postId) {
+            @PathVariable("postId") Long postId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        // 조회수 증가
+        postService.incrementViewCount(postId, request, response);
+
         PostResponseDto dto = postService.getPost(postId);
         return ResponseEntity.ok(dto);
     }

--- a/src/main/java/com/gujo/uminity/post/repository/PostRepository.java
+++ b/src/main/java/com/gujo/uminity/post/repository/PostRepository.java
@@ -4,6 +4,9 @@ import com.gujo.uminity.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     // Pageable 이용
@@ -25,6 +28,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 4. user_userId 기반 검색
     Page<Post> findByUser_UserIdOrderByCreatedAtDesc(String userId, Pageable pageable);
+
+
+    @Modifying
+    @Query("update Post p set p.viewCnt = p.viewCnt + 1 where p.postId = :postId")
+    int incrementViewCount(@Param("postId") Long postId);
+    // findById로 SELECT 한다음 post.setViewCnt 로 업데이트할 때 또 update 쿼리를 가져오니까
+    // postId는 무조건 있다고 생각해서 그냥 조회없이 바로 업데이트하게끔?
 }
 
 /*

--- a/src/main/java/com/gujo/uminity/post/service/PostService.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostService.java
@@ -5,6 +5,8 @@ import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface PostService {
     PageResponse<PostResponseDto> listPosts(PostListRequest req);
@@ -16,12 +18,17 @@ public interface PostService {
     PostResponseDto updatePost(Long postId, PostUpdateRequest request, String userId);
 
     void deletePost(Long postId, String userId);
+
+    /*
+    DIP 의존해서 컨트롤러가 구현체가 아니라 역할에만 의존하도록 캐싱 처리
+
+    인증된 사용자만 자신의 글을 생성 수정 삭제할 수 있게 하려면
+    서비스 계층에서 userId를 받아와야한다.
+    */
+
+    void incrementViewCount(Long postId, HttpServletRequest request, HttpServletResponse response);
+    /* 조회수는 누가봤는지 검증안해도되고 postId만 검증
+    stateless 한 쿠키로 중복 카운팅 방지 - 세션 방식과 쿠키 방식중
+     */
 }
 
-/*
- DIP 의존해서 컨트롤러가 구현체가 아니라 역할에만 의존하도록 캐싱 처리
-
-
- 인증된 사용자만 자신의 글을 생성 수정 삭제할 수 있게 하려면
- 서비스 계층에서 userId를 받아와야한다.
- */

--- a/src/main/java/com/gujo/uminity/post/service/PostService.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostService.java
@@ -1,6 +1,6 @@
 package com.gujo.uminity.post.service;
 
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;

--- a/src/main/java/com/gujo/uminity/post/service/PostService.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostService.java
@@ -5,8 +5,6 @@ import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;
 import com.gujo.uminity.post.dto.response.PostResponseDto;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public interface PostService {
     PageResponse<PostResponseDto> listPosts(PostListRequest req);
@@ -26,9 +24,11 @@ public interface PostService {
     서비스 계층에서 userId를 받아와야한다.
     */
 
-    void incrementViewCount(Long postId, HttpServletRequest request, HttpServletResponse response);
+    void incrementViewCount(Long postId);
     /* 조회수는 누가봤는지 검증안해도되고 postId만 검증
     stateless 한 쿠키로 중복 카운팅 방지 - 세션 방식과 쿠키 방식중
+
+    역할 분리해서 HTTP 쿠키 처리는 컨트롤러가 담당하고 서비스는 조회수 증가 로직만 수행하자!!
      */
 }
 

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -9,9 +9,6 @@ import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
 import com.gujo.uminity.user.entity.User;
 import com.gujo.uminity.user.repository.UserRepository;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -136,34 +133,12 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public void incrementViewCount(Long postId, HttpServletRequest request, HttpServletResponse response) {
+    public void incrementViewCount(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("존재 하지 않는 게시글: " + postId));
+        // 엔티티 성공적으로 로드하면 +1해주자
         post.setViewCnt(post.getViewCnt() + 1);
-
-        // 쿠키에서 viewPosts를 가져오기
-        Cookie[] cookies = request.getCookies();
-        String viewed = "";
-        if (cookies != null) {
-            for (Cookie c : cookies) {
-                if ("viewdPosts".equals(c.getName())) {
-                    viewed = c.getValue();
-                }
-            }
-        }
-        // 아직 안본 게시글 - postId가 포함안되어있으면
-        String marker = "[" + postId + "]";
-        if (!viewed.contains(marker)) {
-            post.setViewCnt(post.getViewCnt() + 1);
-            postRepository.save(post);
-
-            // 쿠키에 유효기간 설정
-            Cookie newCookie = new Cookie("viewPosts", viewed + marker);
-            newCookie.setPath("/");
-            newCookie.setMaxAge(60 * 3); // 일단 3분
-            response.addCookie(newCookie);
-
-        }
+        // 트랜잭션 커밋시 반영
     }
 }
 

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -134,11 +134,12 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public void incrementViewCount(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재 하지 않는 게시글: " + postId));
-        // 엔티티 성공적으로 로드하면 +1해주자
-        post.setViewCnt(post.getViewCnt() + 1);
-        // 트랜잭션 커밋시 반영
+//        Post post = postRepository.findById(postId)
+//                .orElseThrow(() -> new IllegalArgumentException("존재 하지 않는 게시글: " + postId));
+//        // 엔티티 성공적으로 로드하면 +1해주자
+//        post.setViewCnt(post.getViewCnt() + 1);
+//        무조건 postId가 있다고 생각해서 쿼리문을 업데이트만 사용하게끔
+        postRepository.incrementViewCount(postId);
     }
 }
 

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -1,7 +1,5 @@
 package com.gujo.uminity.post.service;
 
-import static java.time.LocalDateTime.now;
-
 import com.gujo.uminity.common.PageResponse;
 import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
@@ -11,6 +9,9 @@ import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
 import com.gujo.uminity.user.entity.User;
 import com.gujo.uminity.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static java.time.LocalDateTime.now;
 
 @Service
 @RequiredArgsConstructor
@@ -78,7 +81,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public PostResponseDto createPost(PostCreateRequest request, String userId) {
-      
+
         // 유저 조회부터 해야됨
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
@@ -129,6 +132,38 @@ public class PostServiceImpl implements PostService {
         }
 
         postRepository.delete(post);
+    }
+
+    @Override
+    @Transactional
+    public void incrementViewCount(Long postId, HttpServletRequest request, HttpServletResponse response) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재 하지 않는 게시글: " + postId));
+        post.setViewCnt(post.getViewCnt() + 1);
+
+        // 쿠키에서 viewPosts를 가져오기
+        Cookie[] cookies = request.getCookies();
+        String viewed = "";
+        if (cookies != null) {
+            for (Cookie c : cookies) {
+                if ("viewdPosts".equals(c.getName())) {
+                    viewed = c.getValue();
+                }
+            }
+        }
+        // 아직 안본 게시글 - postId가 포함안되어있으면
+        String marker = "[" + postId + "]";
+        if (!viewed.contains(marker)) {
+            post.setViewCnt(post.getViewCnt() + 1);
+            postRepository.save(post);
+
+            // 쿠키에 유효기간 설정
+            Cookie newCookie = new Cookie("viewPosts", viewed + marker);
+            newCookie.setPath("/");
+            newCookie.setMaxAge(60 * 3); // 일단 3분
+            response.addCookie(newCookie);
+
+        }
     }
 }
 

--- a/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
+++ b/src/main/java/com/gujo/uminity/post/service/PostServiceImpl.java
@@ -1,6 +1,6 @@
 package com.gujo.uminity.post.service;
 
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;

--- a/src/test/java/com/gujo/uminity/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/gujo/uminity/comment/service/CommentServiceImplTest.java
@@ -6,7 +6,7 @@ import com.gujo.uminity.comment.dto.request.CommentUpdateRequest;
 import com.gujo.uminity.comment.dto.response.CommentResponseDto;
 import com.gujo.uminity.comment.entity.Comment;
 import com.gujo.uminity.comment.repository.CommentRepository;
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.post.entity.Post;
 import com.gujo.uminity.post.repository.PostRepository;
 import com.gujo.uminity.user.entity.User;

--- a/src/test/java/com/gujo/uminity/post/controller/PostControllerTest.java
+++ b/src/test/java/com/gujo/uminity/post/controller/PostControllerTest.java
@@ -1,0 +1,99 @@
+package com.gujo.uminity.post.controller;
+
+import com.gujo.uminity.config.interceptor.ViewCountInterceptor;
+import com.gujo.uminity.post.dto.response.PostResponseDto;
+import com.gujo.uminity.post.service.PostService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostControllerWithInterceptorTest {
+
+    @Mock
+    private PostService postService;
+
+    @InjectMocks
+    private PostController postController;
+
+    private ViewCountInterceptor viewCountInterceptor;
+    private MockMvc mockMvc;
+
+    private final Long POST_ID = 42L;
+
+    @BeforeEach
+    void 인터셉터설정() {
+        viewCountInterceptor = new ViewCountInterceptor(postService);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(postController)
+                .addInterceptors(viewCountInterceptor)
+                .build();
+    }
+
+    @Test
+    @DisplayName("처음조회에는 쿠키 없어서 incrementViewCount 호출하고 쿠키 추가")
+    void 처음조회() throws Exception {
+        // given
+        PostResponseDto dto = PostResponseDto.builder()
+                .postId(POST_ID)
+                .authorName("사람")
+                .title("제목")
+                .content("내용")
+                .createdAt(null)
+                .viewCnt(1)
+                .build();
+        given(postService.getPost(POST_ID)).willReturn(dto);
+
+        // when / then
+        mockMvc.perform(get("/api/posts/{postId}", POST_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.postId").value(POST_ID))
+                // 인터셉터가 Set-Cookie 헤더에 쿠키를 추가하는지 확인
+                .andExpect(cookie().exists("VIEWED_POST_" + POST_ID))
+                .andExpect(cookie().value("VIEWED_POST_" + POST_ID, "true"));
+
+        then(postService).should().incrementViewCount(POST_ID);
+    }
+
+    @Test
+    @DisplayName("이미 본 게시글이면 incrementViewCount 미호출 및 새로운 쿠키 미추가")
+    void 이미본게시글() throws Exception {
+        // given
+        Cookie existing = new Cookie("VIEWED_POST_" + POST_ID, "true");
+        PostResponseDto dto = PostResponseDto.builder()
+                .postId(POST_ID)
+                .authorName("사람")
+                .title("제목")
+                .content("내용")
+                .createdAt(null)
+                .viewCnt(1)
+                .build();
+        given(postService.getPost(POST_ID)).willReturn(dto);
+
+        // when / then
+        mockMvc.perform(get("/api/posts/{postId}", POST_ID)
+                        .cookie(existing)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.postId").value(POST_ID))
+                // 인터셉터가 새로운 쿠키를 추가하지 않아야 함
+                .andExpect(cookie().doesNotExist("VIEWED_POST_" + POST_ID));
+
+        then(postService).should(never()).incrementViewCount(POST_ID);
+    }
+}

--- a/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.gujo.uminity.post.service;
 
-import com.gujo.uminity.common.PageResponse;
+import com.gujo.uminity.common.web.PageResponse;
 import com.gujo.uminity.post.dto.request.PostCreateRequest;
 import com.gujo.uminity.post.dto.request.PostListRequest;
 import com.gujo.uminity.post.dto.request.PostUpdateRequest;

--- a/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/gujo/uminity/post/service/PostServiceImplTest.java
@@ -189,7 +189,7 @@ class PostServiceImplTest {
 
     @Test
     @DisplayName("SEARCH_TYPE=ALL알 때 검색 호출")
-    void listPosts_allSearch() {
+    void 모든게시글조회() {
         // given
         PostListRequest req = new PostListRequest();
         req.setKeyword("키워드");
@@ -214,5 +214,17 @@ class PostServiceImplTest {
         assertThat(page.getTotalElements()).isEqualTo(1);
         assertThat(page.getContent().get(0).getPostId())
                 .isEqualTo(postTest.getPostId());
+    }
+
+    @Test
+    @DisplayName("레포지토리에서만든 JPQL 메소드")
+    void 조회수증가쿼리요청() {
+        // given
+        Long postId = 42L;
+        given(postRepository.incrementViewCount(postId)).willReturn(1);
+        // when
+        postService.incrementViewCount(postId);
+        // then
+        then(postRepository).should().incrementViewCount(postId);
     }
 }


### PR DESCRIPTION
- postId는 무조건 있다고 생각해서 그냥 조회없이 바로 업데이트 하는 JPQL 메소드
- 관심사의 분리 : Service : 조회수 증가, Controller : 클라이언트 요청분기 
- WebConfig : getPost 요청 API Configuration
- ViewCountInterceptor : 쿠키 기반으로 중복조회방지 인터셉터